### PR TITLE
Tweak wlanframegen_assemble() to match typical liquid-dsp behaviour

### DIFF
--- a/src/wlanframegen.c
+++ b/src/wlanframegen.c
@@ -259,6 +259,9 @@ void wlanframegen_assemble(wlanframegen           _q,
     }
 #endif
 
+    // reset state
+    wlanframegen_reset(_q);
+
     // set internal properties
     _q->rate   = _txvector.DATARATE;
     _q->length = _txvector.LENGTH;


### PR DESCRIPTION
Again, trivial tweak - liquid-dsp's *framegen family does framegen reset before assembling a frame. IMO it makes sense to use the same approach in liquid-wlan too.