### PR TITLE
Implemented wlanframegen_getframelen()

### DIFF
--- a/include/liquid-wlan.h
+++ b/include/liquid-wlan.h
@@ -122,6 +122,10 @@ void wlanframegen_print(wlanframegen _q);
 // reset WLAN framing generator object internal state
 void wlanframegen_reset(wlanframegen _q);
 
+// get length of frame (symbols)
+//  _q          :   framing object
+unsigned int wlanframegen_getframelen(wlanframegen _q);
+
 // assemble frame (see Table 76)
 //  _q          :   framing object
 //  _payload    :   raw payload data [size: _opts.LENGTH x 1]

--- a/src/wlanframegen.c
+++ b/src/wlanframegen.c
@@ -235,6 +235,14 @@ void wlanframegen_reset(wlanframegen _q)
     _q->X[37] = 0.0f;
 }
 
+// get length of frame (symbols)
+//  _q              :   framing object
+unsigned int wlanframegen_getframelen(wlanframegen _q)
+{
+    return  5 /* S0a + S0b + S1a + S1b + signal */ + _q->nsym + 1 /* NULL */;
+}
+
+
 // assemble frame (see Table 76)
 //  _q          :   framing object
 //  _payload    :   raw payload data [size: _opts.LENGTH x 1]


### PR DESCRIPTION
This patch adds wlanframegen_getframelen() API and follows related liquid-dsp patterns (returns number of symbols for OFDM-based framegen rather than number of samples as it could be expected).